### PR TITLE
Import django settings in `request_to_hortplus_v2.py`

### DIFF
--- a/soil/skeleton/management/commands/request_to_hortplus_v2.py
+++ b/soil/skeleton/management/commands/request_to_hortplus_v2.py
@@ -12,7 +12,7 @@ from django.utils import timezone
 from datetime import timedelta, date
 from django.contrib import messages
 from skeleton.utils import get_current_season, get_site_season_start_end
-
+from django.conf import settings
 from skeleton.models import Reading, Site, Farm, WeatherStation, Season
 import os
 import json


### PR DESCRIPTION
Closes #7 

This should fix the 'settings is not defined' error when loading rainfall.